### PR TITLE
Add support for player node

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ CSGOGSI.prototype.process = function(data) {
         this.emit('gameCTscore', data.map.team_ct_score);
         this.emit('gameTscore', data.map.team_t_score);
     }
+    
+    if (typeof data.player !== 'undefined') {
+        this.emit('player', data.player);
+    }
 
     if (typeof data.round !== 'undefined') {
 


### PR DESCRIPTION
The addition will transmit all player related nodes: match stats, activity, personal stuff (weapons, armor bought, etc), steamid, etc.